### PR TITLE
Add createResource

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": "true",
     "scripts": {
         "postinstall": "dotnet tool restore",
-        "start": "dotnet fable watch src/App -s -o dist -e .jsx --run vite",
+        "start": "dotnet fable watch src/App -o dist -e .jsx --run vite",
         "publish": "dotnet fsi build.fsx publish"
     },
     "dependencies": {

--- a/src/App/App.fs
+++ b/src/App/App.fs
@@ -8,6 +8,7 @@ open type Components
 
 type Lazy =
     static member Counter() = Solid.lazyImport Counter
+    static member Resource() = Solid.lazyImport Resource
     static member Svg() = Solid.lazyImport Svg
     static member Sketch() = Solid.lazyImport Sketch
     static member TodoElmish() = Solid.lazyImport TodoElmish
@@ -29,6 +30,7 @@ let Tabs() =
                 Html.ul [
                     Html.children [
                         Tab("/counter", "Counter")
+                        Tab("/resource", "Resource")
                         Tab("/svg", "Svg")
                         Tab("/sketch", "Sketch")
                         Tab("/elmish", "Todo Elmish")
@@ -46,6 +48,7 @@ let Tabs() =
             Html.children [
                 Router.Routes [
                     Router.Route("/counter", ``component`` = Lazy.Counter)
+                    Router.Route("/resource", ``component`` = Lazy.Resource)
                     Router.Route("/svg", ``component`` = Lazy.Svg)
                     Router.Route("/sketch", ``component`` = Lazy.Sketch)
                     Router.Route("/elmish", ``component`` = Lazy.TodoElmish)

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -12,11 +12,13 @@
     <Compile Include="Sketch.fs" />
     <Compile Include="TodoElmish.fs" />
     <Compile Include="Shoelace.fs" />
-    <Compile Include="App.fs" />
+      <Compile Include="Resource.fs" />
+      <Compile Include="App.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="4.0.0-theta-005" />
+    <PackageReference Include="Fable.Fetch" Version="2.6.0" />
     <ProjectReference Include="..\Elmish.Solid\Elmish.Solid.fsproj" />
     <PackageReference Include="Feliz.JSX.Solid" Version="1.0.0-beta-001" />
   </ItemGroup>

--- a/src/App/Resource.fs
+++ b/src/App/Resource.fs
@@ -2,42 +2,47 @@
 module Resource
 
 open Fable.Core
-open Fable.Core.JS
 open Feliz.JSX.Solid
 open Fetch
 
 printfn $"Loading {__SOURCE_FILE__}..."
 
-// const fetchUser = async (id) =>
-//   (await fetch(`https://swapi.dev/api/people/${id}/`)).json();
-
 let fetchUser id =
-    promise {
-        let! res = fetch $"https://swapi.dev/api/people/{id}/" []
-        let! json = res.json()
-        return JSON.stringify json
-    }
+    tryFetch $"https://swapi.dev/api/people/{id}/" []
+    |> Promise.bind (function
+        | Ok res -> res.json ()
+        | Error er -> Promise.lift {| error = er.Message |})
+
+[<Emit("Object.keys($0 || {}).map(k => [k, $0[k]])")>]
+let keyValues (o: obj) : (string * obj)[] = nativeOnly
 
 type Components with
+
     [<JSX.Component>]
     static member Resource() =
-        let userId, setUserId = Solid.createSignal(None)
+        let userId, setUserId = Solid.createSignal (None)
         let user, _ = Solid.createResource (userId, fetchUser)
 
-
-        Html.fragment [
-            Html.label $"UserID : {userId()}"
-            Html.br []
-            Html.input [
-                Attr.typeNumber
-                Attr.min 1
-                Attr.placeholder "Enter Numeric Id"
-                Ev.onTextInput (fun (value: string) -> value |> Some |> setUserId)
+        Html.fragment
+            [
+                Html.label $"""UserID: """
+                Html.input
+                    [
+                        Attr.typeNumber
+                        Attr.min 1
+                        Attr.placeholder "Enter Numeric Id"
+                        Ev.onTextInput (fun (value: string) -> value |> Some |> setUserId)
+                    ]
+                Html.ul
+                    [
+                        // Use parenthesis to prevent F# from interpreting
+                        // this as a list builder
+                        (if user.loading then
+                             Html.li "Loading..."
+                         else
+                             Solid.For(
+                                 keyValues user.current,
+                                 fun (k, v) _ -> Html.li [ Html.children [ Html.strong k; Html.text $": {string v}" ] ]
+                             ))
+                    ]
             ]
-            if user.loading then Html.span "Loading" else Html.none
-            Html.div [
-                Html.pre $"{JSON.stringify(user())}"
-            ]
-        ]
-
-

--- a/src/App/Resource.fs
+++ b/src/App/Resource.fs
@@ -1,0 +1,43 @@
+[<AutoOpen>]
+module Resource
+
+open Fable.Core
+open Fable.Core.JS
+open Feliz.JSX.Solid
+open Fetch
+
+printfn $"Loading {__SOURCE_FILE__}..."
+
+// const fetchUser = async (id) =>
+//   (await fetch(`https://swapi.dev/api/people/${id}/`)).json();
+
+let fetchUser id =
+    promise {
+        let! res = fetch $"https://swapi.dev/api/people/{id}/" []
+        let! json = res.json()
+        return JSON.stringify json
+    }
+
+type Components with
+    [<JSX.Component>]
+    static member Resource() =
+        let userId, setUserId = Solid.createSignal(None)
+        let user, _ = Solid.createResource (userId, fetchUser)
+
+
+        Html.fragment [
+            Html.label $"UserID : {userId()}"
+            Html.br []
+            Html.input [
+                Attr.typeNumber
+                Attr.min 1
+                Attr.placeholder "Enter Numeric Id"
+                Ev.onTextInput (fun (value: string) -> value |> Some |> setUserId)
+            ]
+            if user.loading then Html.span "Loading" else Html.none
+            Html.div [
+                Html.pre $"{JSON.stringify(user())}"
+            ]
+        ]
+
+

--- a/src/Fable.Solid/Solid.fs
+++ b/src/Fable.Solid/Solid.fs
@@ -91,11 +91,11 @@ type Solid =
 
     /// Fetcher will be called immediately
     [<ImportMember("solid-js"); ParamObject(fromIndex=1)>]
-    static member createResource(fetcher: unit -> 'T, ?initialValue: 'T): SolidResource<'T> * SolidResourceManager<'T>  = jsNative
+    static member createResource(fetcher: unit -> JS.Promise<'T>, ?initialValue: 'T): SolidResource<'T> * SolidResourceManager<'T>  = jsNative
 
     /// Fetcher will be called only when source signal returns `Some('U)`
     [<ImportMember("solid-js"); ParamObject(fromIndex=2)>]
-    static member createResource(source: unit -> 'U option, fetcher: 'U -> 'T, ?initialValue: 'T): SolidResource<'T> * SolidResourceManager<'T>  = jsNative
+    static member createResource(source: unit -> 'U option, fetcher: 'U -> JS.Promise<'T>, ?initialValue: 'T): SolidResource<'T> * SolidResourceManager<'T>  = jsNative
 
     static member createRef<'El when 'El :> Browser.Types.Element>(): 'El ref = ref Unchecked.defaultof<'El>
 


### PR DESCRIPTION
Fix #6 

`createResource` is very flexible and it's difficult to correctly type all the options in F#. I've tried to handle the most common cases without overcomplicating the API. I'm also ignoring the options for SSR as we don't support it yet.

@kunjee17 Could you please give it a try and let me know if it works for you? It'd be great if you could add an example to the sample App.